### PR TITLE
Update docker image references

### DIFF
--- a/agents.yml
+++ b/agents.yml
@@ -21,6 +21,6 @@ Resources:
   Default:
     Type: Buildkite::ECS::TaskDefinition
     Properties:
-      Image: keithduncan/buildkite-base
-      BuildkiteAgentImage: keithduncan/buildkite-sidecar
+      Image: buildkite/on-demand-base
+      BuildkiteAgentImage: buildkite/agent:3-sidecar
       TaskFamily: buildkite


### PR DESCRIPTION
Update the out the box docker image references to use the Buildkite docker image repositories.

Depends on https://github.com/buildkite/agent/pull/1218